### PR TITLE
Fix: Workspace config is now correctly set on LSP start.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -204,7 +204,7 @@ function getSettings() {
                         addSelect: parseList(getPreference('pyls.plugins.pydocstyle.addSelect') ?? ''),
                         ignore: parseList(getPreference('pyls.plugins.pydocstyle.ignore') ?? ''),
                         select: parseList(getPreference('pyls.plugins.pydocstyle.select') ?? ''),
-                        match: parseList(getPreference('pyls.plugins.pydocstyle.match') ?? ''),
+                        match: getPreference('pyls.plugins.pydocstyle.match'),
                         matchDir: parseList(getPreference('pyls.plugins.pydocstyle.matchDir') ?? '')
                     },
                     pylint: {
@@ -353,7 +353,10 @@ class PythonLanguageServer {
     start() {
         try {
             this.languageClient.start();
-            this.languageClient.sendNotification('workspace/didChangeConfiguration', getSettings());
+            setTimeout(
+                () => this.languageClient.sendNotification('workspace/didChangeConfiguration', getSettings()),
+                200
+            );
         } catch (err) {
             console.error(err);
         }


### PR DESCRIPTION
Previously, the first `workspace/didChangeConfiguration` message  in `start()` was ignored, since the LSP was not running up to that point. By sending the notification with a slight delay (currently 200ms), the message arrives when the server is running. 
This is more of a temporary solution, since the server startup time could possibly vary. Unfortunately, the `.start()` method does not provide any way to detect, whether the LSP start has completed. 

In addition, the `plugins.pydocstyle.match` configuration property has changed from `array of string` to `string`. `getSettings()` has now been modified so that it does not crash upon receiving a configuration notification.

This PR closes #2 

